### PR TITLE
Install pip with zypper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN zypper --non-interactive install \
       java-11-openjdk-devel \
       python \
       python3 \
+      pip \
       sudo \
       tar \
       unzip \


### PR DESCRIPTION
Needed by github.com/bazelbuild/rules_python, as the bazel function pip_install() doesn't seem to install pip correctly.